### PR TITLE
user must be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ services:
             - '7777:7777/udp'
             - '15000:15000/udp'
             - '15777:15777/udp'
-        user: 1000
+        user: '1000'
         volumes:
             - '/path/to/config:/config'
         restart: unless-stopped


### PR DESCRIPTION
After test this error apears:

docker-compose up -d
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.satisfactory-server.user contains an invalid type, it should be a string