### PR TITLE
Add Versioning to Docker Images for GitHub Packages and DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Docker
 on: push
 
-env:
-  IMAGE_NAME: '${{ github.event.repository.name }}'
-
 jobs:
   push:
     runs-on: ubuntu-latest
@@ -41,7 +38,7 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/$IMAGE_NAME:dev
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:dev
             ${{ steps.meta.outputs.tags }}
 
       # - name: Build image for Github Packages

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag image
+        run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
 
       - name: Push image to Github Packages
         run: |
@@ -23,10 +23,12 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "main" ] && VERSION=latest
+          VERSION_HASH=$(echo ${{ github.sha }} | cut -c1-8)
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          docker tag imagelatest $IMAGE_ID:$VERSION
+          docker tag imagehash $IMAGE_ID:$VERSION_HASH
+          docker push $IMAGE_ID --all-tags
       - name: Push image to Docker Hub
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,10 +30,9 @@ jobs:
           docker tag imagehash $IMAGE_ID:$VERSION_HASH
           docker push $IMAGE_ID --all-tags
       - name: Push image to Docker Hub
-        pre: echo ::save-state name=RELEASE_VERSION::$(echo ${{ github.sha }} | cut -c1-8)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
             name: ${{ github.repository }}
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
-            tags: "latest,${{ env.STATE_RELEASE_VERSION }}"
+            tags: "latest,${{ env.VERSION_HASH }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,20 +14,16 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Build image for Github Packages
-        run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
+        run: docker build . --file Dockerfile --tag image
 
       - name: Push image to Github Packages
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "main" ] && VERSION=latest
-          VERSION_HASH=$(echo ${{ github.sha }} | cut -c1-8)
+          VERSION=$(echo ${{ github.sha }} | cut -c1-8)
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          docker tag imagelatest $IMAGE_ID:$VERSION
-          docker tag imagehash $IMAGE_ID:$VERSION_HASH
+          docker tag image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID --all-tags
 
       - name: Docker meta
@@ -41,8 +37,6 @@ jobs:
           tags: |
             type=sha,prefix=,suffix=,format=short
           # always generate latest tag on push
-          flavor: |
-            latest=true
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Log into registry
+      - name: Log into GitHub Packages registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-      - name: Build image
+      - name: Build image for Github Packages
         run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
 
       - name: Push image to Github Packages
@@ -40,6 +40,7 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=sha,prefix=,suffix=,format=short
+          # always generate latest tag on push
           flavor: |
             latest=true
 
@@ -49,7 +50,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push to DockerHub
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,3 +35,4 @@ jobs:
             name: ${{ github.repository }}
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
+            tags: "latest,$VERSION_HASH"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,29 @@ jobs:
           docker tag imagelatest $IMAGE_ID:$VERSION
           docker tag imagehash $IMAGE_ID:$VERSION_HASH
           docker push $IMAGE_ID --all-tags
-      - name: Push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-            name: ${{ github.repository }}
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
-            tags: "latest,${{ env.VERSION_HASH }}"
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+          flavor: |
+            latest=true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo ${{ github.sha }} | cut -c1-8)
+          VERSION=dev
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag image $IMAGE_ID:$VERSION
@@ -35,7 +35,7 @@ jobs:
             ${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=sha,prefix=,suffix=,format=short
+            type=raw,value=dev
           # always generate latest tag on push
 
       - name: Login to DockerHub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,17 +40,3 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:dev
             ${{ steps.meta.outputs.tags }}
-
-      # - name: Build image for Github Packages
-      #   run: docker build . --file Dockerfile --tag image
-            # - name: Push image to Github Packages
-      #   run: |
-      #     IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-      #     IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-      #     VERSION=dev
-      #     echo IMAGE_ID=$IMAGE_ID
-      #     echo VERSION=$VERSION
-      #     docker tag image $IMAGE_ID:$VERSION
-      #     docker push $IMAGE_ID --all-tags
-      # - name: Log into GitHub Packages registry
-      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,9 +30,10 @@ jobs:
           docker tag imagehash $IMAGE_ID:$VERSION_HASH
           docker push $IMAGE_ID --all-tags
       - name: Push image to Docker Hub
+        pre: echo ::save-state name=RELEASE_VERSION::$(echo ${{ github.sha }} | cut -c1-8)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
             name: ${{ github.repository }}
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
-            tags: "latest,$VERSION_HASH"
+            tags: "latest,${{ env.STATE_RELEASE_VERSION }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,21 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Log into GitHub Packages registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-      - name: Build image for Github Packages
-        run: docker build . --file Dockerfile --tag image
-
-      - name: Push image to Github Packages
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=dev
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID --all-tags
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -38,15 +35,25 @@ jobs:
             type=raw,value=dev
           # always generate latest tag on push
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push to DockerHub
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ghcr.io/${{ github.repository }}/$IMAGE_NAME:dev
+            ${{ steps.meta.outputs.tags }}
+
+      # - name: Build image for Github Packages
+      #   run: docker build . --file Dockerfile --tag image
+            # - name: Push image to Github Packages
+      #   run: |
+      #     IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+      #     IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+      #     VERSION=dev
+      #     echo IMAGE_ID=$IMAGE_ID
+      #     echo VERSION=$VERSION
+      #     docker tag image $IMAGE_ID:$VERSION
+      #     docker push $IMAGE_ID --all-tags
+      # - name: Log into GitHub Packages registry
+      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=sha
+            type=sha,prefix=,suffix=,format=short
           flavor: |
             latest=true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,52 +6,52 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-        - name: Log into GitHub Packages registry
-          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Log into GitHub Packages registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-        - name: Build image for Github Packages
-          run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
+      - name: Build image for Github Packages
+        run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
 
-        - name: Push image to Github Packages
-          run: |
-            IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-            IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-            [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-            [ "$VERSION" == "main" ] && VERSION=latest
-            VERSION_RELEASE=$(echo ${{ github.event.release.tag_name }})
-            echo IMAGE_ID=$IMAGE_ID
-            echo VERSION=$VERSION
-            docker tag imagelatest $IMAGE_ID:$VERSION
-            docker tag imagehash $IMAGE_ID:$VERSION_RELEASE
-            docker push $IMAGE_ID --all-tags
+      - name: Push image to Github Packages
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "main" ] && VERSION=latest
+          VERSION_RELEASE=$(echo ${{ github.event.release.tag_name }})
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag imagelatest $IMAGE_ID:$VERSION
+          docker tag imagehash $IMAGE_ID:$VERSION_RELEASE
+          docker push $IMAGE_ID --all-tags
 
-        - name: Docker meta
-          id: meta
-          uses: docker/metadata-action@v3
-          with:
-            # list of Docker images to use as base name for tags
-            images: |
-              ${{ github.repository }}
-            # generate Docker tags based on the following events/attributes
-            tags: |
-              type=semver,pattern={{raw}}
-            # always generate latest tag on push
-            flavor: |
-              latest=true
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{raw}}
+          # always generate latest tag on push
+          flavor: |
+            latest=true
 
-        - name: Login to DockerHub
-          uses: docker/login-action@v1 
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-        - name: Build and push to DockerHub
-          id: docker_build
-          uses: docker/build-push-action@v2
-          with:
-            push: true
-            tags: ${{ steps.meta.outputs.tags }}
+      - name: Build and push to DockerHub
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+on: 
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Log into GitHub Packages registry
+          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+        - name: Build image for Github Packages
+          run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
+
+        - name: Push image to Github Packages
+          run: |
+            IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+            IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+            [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+            [ "$VERSION" == "main" ] && VERSION=latest
+            VERSION_RELEASE=$(echo ${{ github.event.release.tag_name }})
+            echo IMAGE_ID=$IMAGE_ID
+            echo VERSION=$VERSION
+            docker tag imagelatest $IMAGE_ID:$VERSION
+            docker tag imagehash $IMAGE_ID:$VERSION_RELEASE
+            docker push $IMAGE_ID --all-tags
+
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v3
+          with:
+            # list of Docker images to use as base name for tags
+            images: |
+              ${{ github.repository }}
+            # generate Docker tags based on the following events/attributes
+            tags: |
+              type=semver,pattern={{raw}}
+            # always generate latest tag on push
+            flavor: |
+              latest=true
+
+        - name: Login to DockerHub
+          uses: docker/login-action@v1 
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Build and push to DockerHub
+          id: docker_build
+          uses: docker/build-push-action@v2
+          with:
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,17 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Build image for Github Packages
-        run: docker build . --file Dockerfile --tag imagelatest --tag imagehash
+        run: docker build . --file Dockerfile --tag imagelatest --tag image
 
       - name: Push image to Github Packages
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "main" ] && VERSION=latest
-          VERSION_RELEASE=$(echo ${{ github.event.release.tag_name }})
+          VERSION=$(echo ${{ github.event.release.tag_name }})
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          docker tag imagelatest $IMAGE_ID:$VERSION
-          docker tag imagehash $IMAGE_ID:$VERSION_RELEASE
+          docker tag imagelatest $IMAGE_ID:latest
+          docker tag image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID --all-tags
 
       - name: Docker meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           flavor: |
             latest=true
 
-      - name: Build and push to DockerHub
+      - name: Build and push to DockerHub & GitHub Packages
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,22 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Log into GitHub Packages registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build image for Github Packages
-        run: docker build . --file Dockerfile --tag imagelatest --tag image
-
-      - name: Push image to Github Packages
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo ${{ github.event.release.tag_name }})
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag imagelatest $IMAGE_ID:latest
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID --all-tags
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -43,15 +39,12 @@ jobs:
           flavor: |
             latest=true
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push to DockerHub
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:latest
+          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}
+          ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+env:
+  IMAGE_NAME: '${{ github.event.repository.name }}'
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,15 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{raw}}
+            type=raw,value=ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:latest
+            type=raw,value=ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}
           # always generate latest tag on push
           flavor: |
             latest=true
 
       - name: Build and push to DockerHub
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: |
-          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:latest
-          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:$TAG_NAME
-          ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,12 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=semver,pattern={{raw}}
-            type=raw,value=ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:latest
-            type=raw,value=ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
           # always generate latest tag on push
           flavor: |
             latest=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ on:
   release:
     types: [published]
 
-env:
-  IMAGE_NAME: '${{ github.event.repository.name }}'
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -40,11 +37,13 @@ jobs:
             latest=true
 
       - name: Build and push to DockerHub
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
           tags: |
           ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:latest
-          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}
+          ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}:$TAG_NAME
           ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cm2network/steamcmd:root
 
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo=1.8.27-1+deb10u3 --no-install-recommends\
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /config \


### PR DESCRIPTION
Hello! I've added versioning mentioned in Issue #77. 
This required some changes to the way it builds and pushes to the DockerHub & Github Packages.
For Github Packages this only required to add a version hash and push that to the registry as well.
For DockerHub i've opted to use different github action steps as that made it easier to dynamically create tag hashes, this also enables you to more easily add docker tags for releases if you ever plan on doing so :) 
Preview of [tags on DockerHub](https://hub.docker.com/repository/registry-1.docker.io/thijsvanloef/satisfactory-server/tags?page=1&ordering=last_updated)
Preview of [tags on GitHub Packages](https://github.com/thijsvanloef/satisfactory-server/packages/1083103)