### PR TITLE
:bug: fixes lost config with custom query port

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ cp -a /config/saves/. /config/backups/
 cp -a "${GAMESAVESDIR}/server/." /config/backups # useless in first run, but useful in additional runs
 rm -rf "${GAMESAVESDIR}/server"
 ln -sf /config/saves "${GAMESAVESDIR}/server"
-ln -sf /config/ServerSettings.15777 "${GAMESAVESDIR}/ServerSettings.15777"
+ln -sf "/config/ServerSettings.${SERVERQUERYPORT}" "${GAMESAVESDIR}/ServerSettings.${SERVERQUERYPORT}"
 
 cp /home/steam/{Engine.ini,Game.ini,Scalability.ini} "${GAMECONFIGDIR}/Config/LinuxServer"
 

--- a/run.sh
+++ b/run.sh
@@ -38,10 +38,10 @@ else
     printf "Skipping update as flag is set\\n"
 fi
 
-cp -a /config/saves/. /config/backups/
-cp -a "${GAMESAVESDIR}/server/." /config/backups # useless in first run, but useful in additional runs
+cp -a "/config/saves/." "/config/backups/"
+cp -a "${GAMESAVESDIR}/server/." "/config/backups" # useless in first run, but useful in additional runs
 rm -rf "${GAMESAVESDIR}/server"
-ln -sf /config/saves "${GAMESAVESDIR}/server"
+ln -sf "/config/saves" "${GAMESAVESDIR}/server"
 ln -sf "/config/ServerSettings.${SERVERQUERYPORT}" "${GAMESAVESDIR}/ServerSettings.${SERVERQUERYPORT}"
 
 cp /home/steam/{Engine.ini,Game.ini,Scalability.ini} "${GAMECONFIGDIR}/Config/LinuxServer"


### PR DESCRIPTION
When using a SERVERQUERYPORT other than the default 15777, the server config is lost when the container is down.