### PR TITLE
Fix steamcmd to properly use STEAMBETAFLAG

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -27,8 +27,8 @@ if [[ "$SKIPUPDATE" == "false" ]]; then
     fi
 
     printf "Downloading the latest version of the game...\\n"
-
-    /home/steam/steamcmd/steamcmd.sh +login anonymous +force_install_dir /config/gamefiles +app_update "$STEAMAPPID" "$STEAMBETAFLAG" +quit
+    
+    /home/steam/steamcmd/steamcmd.sh +login anonymous +force_install_dir /config/gamefiles +app_update "$STEAMAPPID" $STEAMBETAFLAG +quit
 else
     printf "Skipping update as flag is set\\n"
 fi

--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ if [[ "$SKIPUPDATE" == "false" ]]; then
 
     printf "Downloading the latest version of the game...\\n"
 
-    /home/steam/steamcmd/steamcmd.sh +login anonymous +force_install_dir /config/gamefiles +app_update "$STEAMAPPID$STEAMBETAFLAG" +quit
+    /home/steam/steamcmd/steamcmd.sh +login anonymous +force_install_dir /config/gamefiles +app_update "$STEAMAPPID" "$STEAMBETAFLAG" +quit
 else
     printf "Skipping update as flag is set\\n"
 fi


### PR DESCRIPTION
It seems the STEAMBETAFLAG is not properly passed to steamcmd. This fixes issues with server being out of date when using the experimental branch.