### PR TITLE
Use gosu and execs for execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ RUN set -x \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo=1.8.27-1+deb10u3 --no-install-recommends\
     && rm -rf /var/lib/apt/lists/*
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+# verify that the binary works
+	gosu nobody true
+
 RUN mkdir -p /config \
  && chown steam:steam /config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,9 @@ FROM cm2network/steamcmd:root
 
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo=1.8.27-1+deb10u3 --no-install-recommends\
-    && rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y gosu; \
-	rm -rf /var/lib/apt/lists/*; \
-# verify that the binary works
-	gosu nobody true
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y gosu --no-install-recommends\
+    && rm -rf /var/lib/apt/lists/*  \
+    && gosu nobody true
 
 RUN mkdir -p /config \
  && chown steam:steam /config

--- a/init.sh
+++ b/init.sh
@@ -54,4 +54,4 @@ fi
 
 chown -R "${PUID}":"${PGID}" /config /home/steam
 
-sudo -u "${USER}" -E -H sh -c "/home/steam/run.sh"
+exec gosu "${USER}" "/home/steam/run.sh" "$@"

--- a/run.sh
+++ b/run.sh
@@ -88,4 +88,4 @@ fi
 
 cd /config/gamefiles || exit 1
 
-exec Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP" "$@"
+exec ./Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP" "$@"

--- a/run.sh
+++ b/run.sh
@@ -88,4 +88,4 @@ fi
 
 cd /config/gamefiles || exit 1
 
-Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP"
+exec Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP"

--- a/run.sh
+++ b/run.sh
@@ -88,4 +88,4 @@ fi
 
 cd /config/gamefiles || exit 1
 
-exec Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP"
+exec Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP" "$@"


### PR DESCRIPTION
Use exec at the end of scripts in order to simplify the process chain
and signal handling.  With this change, a SIGTERM sent by docker to
PID 1 will be propagated to the server binary for a clean shutdown.

Resolves #99 