### PR TITLE
+force_install_dir after +login throws an error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -68,7 +68,7 @@ if ! [[ "${SKIPUPDATE,,}" == "true" ]]; then
 
     printf "Downloading the latest version of the game...\\n"
     
-    /home/steam/steamcmd/steamcmd.sh +login anonymous +force_install_dir /config/gamefiles +app_update "$STEAMAPPID" $STEAMBETAFLAG +quit
+    /home/steam/steamcmd/steamcmd.sh +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID" $STEAMBETAFLAG +quit
 else
     printf "Skipping update as flag is set\\n"
 fi


### PR DESCRIPTION
Current `run.sh` structure throws following error : 

```
Connecting anonymously to Steam Public...OK
Waiting for client config...OK
Waiting for user info...OK
Please use force_install_dir before logon!

```

Moved `+force_install_dir /config/gamefiles` before `+login` , solved the issue