### PR TITLE
Added NETWORKQUALITY to environment and GameUserSettings.ini (default 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV AUTOPAUSE="true" \
     GAMECONFIGDIR="/config/gamefiles/FactoryGame/Saved" \
     GAMESAVESDIR="/home/steam/.config/Epic/FactoryGame/Saved/SaveGames" \
     MAXPLAYERS="4" \
+    NETWORKQUALITY="3" \
     PGID="1000" \
     PUID="1000" \
     SERVERBEACONPORT="15000" \

--- a/run.sh
+++ b/run.sh
@@ -46,7 +46,6 @@ set_ini_val "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "
 printf "Setting disable seasonal events to %s\\n" "${DISABLESEASONALEVENTS}"
 set_ini_val "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "FG.DisableSeasonalEvents" "${DISABLESEASONALEVENTS}"
 
-
 if ! [[ "$NETWORKQUALITY" =~ $NUMCHECK ]] ; then
     printf "Invalid network quality number given: %s\\n" "${NETWORKQUALITY}"
     NETWORKQUALITY="3"

--- a/run.sh
+++ b/run.sh
@@ -45,6 +45,14 @@ set_ini_val "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "
 [[ "${DISABLESEASONALEVENTS,,}" == "true" ]] && DISABLESEASONALEVENTS="1" || DISABLESEASONALEVENTS="0"
 printf "Setting disable seasonal events to %s\\n" "${DISABLESEASONALEVENTS}"
 set_ini_val "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "FG.DisableSeasonalEvents" "${DISABLESEASONALEVENTS}"
+
+
+if ! [[ "$NETWORKQUALITY" =~ $NUMCHECK ]] ; then
+    printf "Invalid network quality number given: %s\\n" "${NETWORKQUALITY}"
+    NETWORKQUALITY="3"
+fi
+printf "Setting network quality number to %s\\n" "${NETWORKQUALITY}"
+set_ini_prop "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "mNetworkQuality" "${AUTOSAVENUM}"
 ## END GameUserSettings.ini
 
 ## START ServerSettings.ini

--- a/run.sh
+++ b/run.sh
@@ -51,7 +51,7 @@ if ! [[ "$NETWORKQUALITY" =~ $NUMCHECK ]] ; then
     NETWORKQUALITY="3"
 fi
 printf "Setting network quality number to %s\\n" "${NETWORKQUALITY}"
-set_ini_prop "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "mNetworkQuality" "${AUTOSAVENUM}"
+set_ini_prop "GameUserSettings.ini" "\/Script\/FactoryGame\.FGGameUserSettings" "mNetworkQuality" "${NETWORKQUALITY}"
 ## END GameUserSettings.ini
 
 ## START ServerSettings.ini


### PR DESCRIPTION
GameUserSettings.ini has an option for mNetworkQuality.
The games default value here is mNetworkQuality=0.
This refers to the ingame option "Network Quality" with the default value "normal".

I have added an environment variable to run.sh with the default value 3.
This equates to the ingame setting "Ultra"

Source
https://help.akliz.net/docs/common-satisfactory-errors

Unfortunately this option is not documented very well. The NetworkQuality setting is defined in Scalability.ini
```[NetworkQuality@3]
TotalNetBandwidth=104857600
MaxDynamicBandwidth=104857600
MinDynamicBandwidth=10485760```
The bandwidth setting helps avoiding sync lags with conveyer belts.