### PR TITLE
fix: dedicated server blueprint persistence

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -37,7 +37,15 @@ if [[ "$ramAvailable" -lt 12 ]]; then
     printf "You have less than the required 12GB minmum (%sGB detected) of available RAM to run the game server.\\nIt is likely that the server will fail to load properly.\\n" "${ramAvailable}"
 fi
 
-mkdir -p /config/backups /config/gamefiles /config/saves "${GAMECONFIGDIR}/Config/LinuxServer" "${GAMECONFIGDIR}/Logs" "${GAMECONFIGDIR}/SaveGames/server" "${GAMESAVESDIR}/server" || exit 1
+mkdir -p \
+    /config/backups \
+    /config/blueprints \
+    /config/gamefiles \
+    /config/saves \
+    "${GAMECONFIGDIR}/Config/LinuxServer" \
+    "${GAMECONFIGDIR}/Logs" \
+    "${GAMESAVESDIR}/server" \
+  || exit 1
 
 NUMCHECK='^[0-9]+$'
 

--- a/run.sh
+++ b/run.sh
@@ -104,8 +104,8 @@ fi
 cp -a "/config/saves/." "/config/backups/"
 cp -a "${GAMESAVESDIR}/server/." "/config/backups" # useless in first run, but useful in additional runs
 rm -rf "${GAMESAVESDIR}/server"
-ln -sf "/config/saves" "${GAMESAVESDIR}/server"
 ln -sf "/config/blueprints" "${GAMESAVESDIR}/blueprints"
+ln -sf "/config/saves" "${GAMESAVESDIR}/server"
 ln -sf "/config/ServerSettings.${SERVERQUERYPORT}" "${GAMESAVESDIR}/ServerSettings.${SERVERQUERYPORT}"
 
 cp /home/steam/*.ini "${GAMECONFIGDIR}/Config/LinuxServer"

--- a/run.sh
+++ b/run.sh
@@ -105,6 +105,7 @@ cp -a "/config/saves/." "/config/backups/"
 cp -a "${GAMESAVESDIR}/server/." "/config/backups" # useless in first run, but useful in additional runs
 rm -rf "${GAMESAVESDIR}/server"
 ln -sf "/config/saves" "${GAMESAVESDIR}/server"
+ln -sf "/config/blueprints" "${GAMESAVESDIR}/blueprints"
 ln -sf "/config/ServerSettings.${SERVERQUERYPORT}" "${GAMESAVESDIR}/ServerSettings.${SERVERQUERYPORT}"
 
 cp /home/steam/*.ini "${GAMECONFIGDIR}/Config/LinuxServer"


### PR DESCRIPTION
Previously, the new "blueprints" directory from Update 7 in SavedGames ("${GAMESAVESDIR}") was not part of the state that persisted between container instances. This follows the existing pattern of linking to a directory in /config, which is assumed to be mounted from a long-lived location.

See also: https://www.reddit.com/r/SatisfactoryGame/comments/z703b0/dedicated_server_blueprint_upload_location/