### PR TITLE
Update base image to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM steamcmd/steamcmd:ubuntu-22
 
 RUN set -x \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y gosu --no-install-recommends\
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y gosu xdg-user-dirs --no-install-recommends\
  && rm -rf /var/lib/apt/lists/* \
  && useradd -ms /bin/bash steam \
  && gosu nobody true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM steamcmd/steamcmd:ubuntu-18
+FROM steamcmd/steamcmd:ubuntu-22
 
 RUN set -x \
  && apt-get update \

--- a/init.sh
+++ b/init.sh
@@ -72,5 +72,5 @@ else
     usermod -u "$PUID" steam
 fi
 
-chown -R "$PUID":"$PGID" /config /home/steam
+chown -R "$PUID":"$PGID" /config /home/steam /tmp/dumps
 exec gosu "$USER" "/home/steam/run.sh" "$@"


### PR DESCRIPTION
I've been running this image with a base of Ubuntu 22.04 for a while now, and encountered no new issues with stability or runtime issues.

I'm proposing this change as this seemed to solve connection issues via IPv6 forwards that I had. No idea why or how this affects container networking, and probably best to review this with k8s setups in case anything else is affected.

Included in this PR are a couple of log error silencing fixes:
* Added `/tmp/dumps` to steam ownership
* `xdg-user-dirs` package added for server initialisation