### PR TITLE
Use FactoryServer.sh for daemon execution

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -145,11 +145,11 @@ rm -rf "$GAMESAVESDIR"
 ln -sf "/config/saved" "$GAMESAVESDIR"
 cp /home/steam/*.ini "${GAMECONFIGDIR}/Config/LinuxServer/"
 
-if [ ! -f "/config/gamefiles/Engine/Binaries/Linux/UE4Server-Linux-Shipping" ]; then
-    printf "Game binary is missing.\\n"
+if [ ! -f "/config/gamefiles/FactoryServer.sh" ]; then
+    printf "FactoryServer launch script is missing.\\n"
     exit 1
 fi
 
 cd /config/gamefiles || exit 1
 
-exec ./Engine/Binaries/Linux/UE4Server-Linux-Shipping FactoryGame -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP" "$@"
+exec ./FactoryServer.sh -log -NoSteamClient -unattended ?listen -Port="$SERVERGAMEPORT" -BeaconPort="$SERVERBEACONPORT" -ServerQueryPort="$SERVERQUERYPORT" -multihome="$SERVERIP" "$@"


### PR DESCRIPTION
FactoryServer.sh sets up a few environment variables and provides the path to the server binary for launching Satisfactory Dedicated server. I do not believe this env vars are used during execution.

With the migration to UE5 imminent for the experimental channel, this should handle changes to the game files that may include a new path to launching the server.