### PR TITLE
Updated memory limit based on my experience with update 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ You'll need to bind a local directory to the Docker container's `/config` direct
 
 Before running the server image, you should find your user ID that will be running the container. This isn't necessary in most cases, but it's good to find out regardless. If you're seeing `permission denied` errors, then this is probably why. Find your ID in `Linux` by running the `id` command. Then grab the user ID (usually something like `1000`) and pass it into the `-e PGID=1000` and `-e PUID=1000` environment variables.
 
-Run the Satisfactory server image like this:
+Run the Satisfactory server image like this:<br>
+Note: This is one command make sure to copy all of it!
 
 ```bash
 docker run \
---sig-proxy=false \
+--detached \
 --name=satisfactory-server \
 --hostname satisfactory-server \
 --restart unless-stopped \
@@ -39,6 +40,21 @@ docker run \
 -p 15777:15777/udp \
 wolveix/satisfactory-server:latest
 ```
+
+    <details>
+    <summary>Explanation of the command</summary>
+    * `--detached` -> Starts the container detached from your terminal.
+    If you want to see the logs replace it with `--sig-proxy=false`.
+    * `--name` -> Gives the container a unqiue name.
+    * `--hostname` -> Changes the hostname of the container.
+    * `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.
+    * `-v` -> Binds the satisfactory config folder to the folder you specified. Allows you to easily access your savegames.
+    * For the environment (`-e`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
+    * `--memory-reservation` -> Is a memory soft limit.
+    * `-m 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
+    * `-p` -> Specifies the ports that the container exposes.<br>
+    Should only be changed if you know what you are doing. For more information please refer to the [docker documentation](https://docs.docker.com/engine/reference/run/).
+    </details>
 
 ### Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,21 @@ Before running the server image, you should find your user ID that will be runni
 Run the Satisfactory server image like this:
 
 ```bash
-docker run -d --name=satisfactory-server -h satisfactory-server -e MAXPLAYERS=4 -e PGID=1000 -e PUID=1000 -e STEAMBETA=false -v /path/to/config:/config -m 16G --memory-reservation=12G -p 7777:7777/udp -p 15000:15000/udp -p 15777:15777/udp wolveix/satisfactory-server:latest
+docker run \
+--sig-proxy=false \
+--name=satisfactory-server \
+-hostname satisfactory-server \
+-p 7777:7777/udp \
+-p 15000:15000/udp \
+-p 15777:15777/udp \
+-e MAXPLAYERS=4 \
+-e PGID=1000 \
+-e PUID=1000 \
+-e STEAMBETA=false \
+-v /path/to/config:/config \
+--memory-reservation=12G \
+-m 16G \
+wolveix/satisfactory-server:latest
 ```
 
 ### Docker Compose

--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ docker run \
 wolveix/satisfactory-server:latest
 ```
 
-    <details>
-    <summary>Explanation of the command</summary>
-    * `--detached` -> Starts the container detached from your terminal.
-    If you want to see the logs replace it with `--sig-proxy=false`.
+    <details> <summary>Explanation of the command:</summary>
+    * `--detached` -> Starts the container detached from your terminal. If you
+      want to see the logs replace it with `--sig-proxy=false`.
     * `--name` -> Gives the container a unqiue name.
     * `--hostname` -> Changes the hostname of the container.
-    * `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.
-    * `-v` -> Binds the satisfactory config folder to the folder you specified. Allows you to easily access your savegames.
-    * For the environment (`-e`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
+    * `--restart unless-stopped` -> Enables the restart policy that restarts
+      the container unless it was stopped by the user.
+    * `-v` -> Binds the satisfactory config folder to the folder you specified.
+      Allows you to easily access your savegames.
+    * For the environment (`-e`) variables please see
+      [here](https://github.com/wolveix/satisfactory-server#environment-variables).
     * `--memory-reservation` -> Is a memory soft limit.
     * `-m 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
-    * `-p` -> Specifies the ports that the container exposes.<br>
-    Should only be changed if you know what you are doing. For more information please refer to the [docker documentation](https://docs.docker.com/engine/reference/run/).
+    * `-p` -> Specifies the ports that the container exposes.<br> 
     </details>
 
 ### Docker Compose

--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ Run the Satisfactory server image like this:
 docker run \
 --sig-proxy=false \
 --name=satisfactory-server \
--hostname satisfactory-server \
--p 7777:7777/udp \
--p 15000:15000/udp \
--p 15777:15777/udp \
+--hostname satisfactory-server \
+--restart always
+-v /path/to/config:/config \
 -e MAXPLAYERS=4 \
 -e PGID=1000 \
 -e PUID=1000 \
 -e STEAMBETA=false \
--v /path/to/config:/config \
 --memory-reservation=12G \
 -m 16G \
+-p 7777:7777/udp \
+-p 15000:15000/udp \
+-p 15777:15777/udp \
 wolveix/satisfactory-server:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ docker run \
 wolveix/satisfactory-server:latest
 ```
 
-    <details> <summary>Explanation of the command:</summary>
-    * `--detached` -> Starts the container detached from your terminal. If you
-      want to see the logs replace it with `--sig-proxy=false`.
-    * `--name` -> Gives the container a unqiue name.
-    * `--hostname` -> Changes the hostname of the container.
-    * `--restart unless-stopped` -> Enables the restart policy that restarts
-      the container unless it was stopped by the user.
-    * `-v` -> Binds the satisfactory config folder to the folder you specified.
-      Allows you to easily access your savegames.
-    * For the environment (`-e`) variables please see
-      [here](https://github.com/wolveix/satisfactory-server#environment-variables).
-    * `--memory-reservation` -> Is a memory soft limit.
-    * `-m 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
-    * `-p` -> Specifies the ports that the container exposes.<br> 
-    </details>
+<details> 
+<summary>Explanation of the command:</summary>
+
+* `--detached` -> Starts the container detached from your terminal. If you
+want to see the logs replace it with `--sig-proxy=false`.
+* `--name` -> Gives the container a unqiue name.
+* `--hostname` -> Changes the hostname of the container.
+* `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.
+* `-v` -> Binds the satisfactory config folder to the folder you specified.
+Allows you to easily access your savegames.
+* For the environment (`-e`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
+* `--memory-reservation` -> Is a memory soft limit.
+* `-m 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
+* `-p` -> Specifies the ports that the container exposes.<br> 
+</details>
 
 ### Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to see the logs replace it with `--sig-proxy=false`.
 * `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.
 * `--volume` -> Binds the satisfactory config folder to the folder you specified.
 Allows you to easily access your savegames.
-* For the environment (`-e`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
+* For the environment (`--env`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
 * `--memory-reservation` -> Is a memory soft limit.
 * `--memory 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
 * `--publish` -> Specifies the ports that the container exposes.<br> 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a Dockerized version of the [Satisfactory](https://store.steampowered.co
 
 ## Setup
 
-According to [the official wiki](https://satisfactory.wiki.gg/wiki/Dedicated_servers), expect to need 12GB - 16GB of RAM.
+According to [the official wiki](https://satisfactory.wiki.gg/wiki/Dedicated_servers), expect to need 2GB - 5GB of RAM.
 
 You'll need to bind a local directory to the Docker container's `/config` directory. This directory will hold the following directories:
 
@@ -34,7 +34,7 @@ docker run \
 --env PUID=1000 \
 --env STEAMBETA=false \
 --memory-reservation=12G \
---memory 16G \
+--memory 5G \
 --publish 7777:7777/udp \
 --publish 15000:15000/udp \
 --publish 15777:15777/udp \
@@ -53,7 +53,7 @@ If you want to see the logs replace it with `--sig-proxy=false`.
 Allows you to easily access your savegames.
 * For the environment (`--env`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
 * `--memory-reservation` -> Is a memory soft limit.
-* `--memory 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
+* `--memory 5G` -> Limits the RAM that the container uses to 5 Gigabytes.
 * `--publish` -> Specifies the ports that the container exposes.<br> 
 </details>
 
@@ -83,7 +83,7 @@ services:
         deploy:
           resources:
             limits:
-              memory: 16G
+              memory: 5G
             reservations:
               memory: 12G
 ```

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ docker run \
 --name=satisfactory-server \
 --hostname satisfactory-server \
 --restart unless-stopped \
--v /path/to/config:/config \
--e MAXPLAYERS=4 \
--e PGID=1000 \
--e PUID=1000 \
--e STEAMBETA=false \
+--volume /path/to/config:/config \
+--env MAXPLAYERS=4 \
+--env PGID=1000 \
+--env PUID=1000 \
+--env STEAMBETA=false \
 --memory-reservation=12G \
--m 16G \
--p 7777:7777/udp \
--p 15000:15000/udp \
--p 15777:15777/udp \
+--memory 16G \
+--publish 7777:7777/udp \
+--publish 15000:15000/udp \
+--publish 15777:15777/udp \
 wolveix/satisfactory-server:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ If you want to see the logs replace it with `--sig-proxy=false`.
 * `--name` -> Gives the container a unqiue name.
 * `--hostname` -> Changes the hostname of the container.
 * `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.
-* `-v` -> Binds the satisfactory config folder to the folder you specified.
+* `--volume` -> Binds the satisfactory config folder to the folder you specified.
 Allows you to easily access your savegames.
 * For the environment (`-e`) variables please see [here](https://github.com/wolveix/satisfactory-server#environment-variables).
 * `--memory-reservation` -> Is a memory soft limit.
-* `-m 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
-* `-p` -> Specifies the ports that the container exposes.<br> 
+* `--memory 16G` -> Limits the RAM that the container uses to 16 Gigabytes.
+* `--publish` -> Specifies the ports that the container exposes.<br> 
 </details>
 
 ### Docker Compose

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ wolveix/satisfactory-server:latest
 <details> 
 <summary>Explanation of the command:</summary>
 
-* `--detached` -> Starts the container detached from your terminal. If you
-want to see the logs replace it with `--sig-proxy=false`.
+* `--detached` -> Starts the container detached from your terminal.<br> 
+If you want to see the logs replace it with `--sig-proxy=false`.
 * `--name` -> Gives the container a unqiue name.
 * `--hostname` -> Changes the hostname of the container.
 * `--restart unless-stopped` -> Enables the restart policy that restarts the container unless it was stopped by the user.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run \
 --sig-proxy=false \
 --name=satisfactory-server \
 --hostname satisfactory-server \
---restart always
+--restart unless-stopped \
 -v /path/to/config:/config \
 -e MAXPLAYERS=4 \
 -e PGID=1000 \


### PR DESCRIPTION
I loaded up a bigger safe and the server didn't consumed more than 4GB (so I updated to 5GB)

<b>This only applies to update 8 so this PR is draft atm until update 8 gets released to the early access branche.</b>