### PR TITLE
Improved docker compose env syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ services:
         volumes:
             - '/path/to/config:/config'
         environment:
-            - MAXPLAYERS=4
-            - PGID=1000
-            - PUID=1000
-            - ROOTLESS=false
-            - STEAMBETA=false
+            MAXPLAYERS: 4
+            PGID: 1000
+            PUID: 1000
+            ROOTLESS: false
+            STEAMBETA: false
         restart: unless-stopped
         deploy:
           resources:


### PR DESCRIPTION
Hey,

I used the more readable version to declare env variables.
Just a minor improvement.