### PR TITLE
init.sh: make grep for CPU model name more robust

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -19,7 +19,7 @@ if [[ "${DEBUG,,}" == "true" ]]; then
     echo "
 System info:
 OS:  $(uname -a)
-CPU: $(lscpu | grep 'Model name:' | sed 's/Model name:[[:space:]]*//g')
+CPU: $(lscpu | grep '^Model name:' | sed 's/Model name:[[:space:]]*//g')
 RAM: $(awk '/MemAvailable/ {printf( "%d\n", $2 / 1024000 )}' /proc/meminfo)GB/$(awk '/MemTotal/ {printf( "%d\n", $2 / 1024000 )}' /proc/meminfo)GB
 HDD: $(df -h | awk '$NF=="/"{printf "%dGB/%dGB (%s used)\n", $3,$2,$5}')"
     printf "\\nCurrent version:\\n%s" "${VERSION}"


### PR DESCRIPTION
On my VM (though not within Docker) the previous grep matched for the BIOS name too:

```
# lscpu | grep 'Model name:'
Model name:                           AMD EPYC 7282 16-Core Processor
BIOS Model name:                      pc-i440fx-5.2  CPU @ 2.0GHz
```