### PR TITLE
healthcheck.sh: Fail when API call fails; No curl progress

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -o pipefail
 
-curl -k -f -X POST "https://127.0.0.1:${SERVERGAMEPORT}/api/v1" \
+curl -k -f -s -S -X POST "https://127.0.0.1:${SERVERGAMEPORT}/api/v1" \
 -H "Content-Type: application/json" \
 -d '{"function":"HealthCheck","data":{"clientCustomData":""}}' \
 | jq -e '.data.health == "healthy"'


### PR DESCRIPTION
Couple fixes to `healthcheck.sh`:

- Adds `set -o pipefail` to make sure jq fails when the curl call fails.
  - I assume this would be the intended behavior, though I wonder about if server startup takes too long (ie steam is updating the client still) that this might cause issues... If preferred, I can pull this out and research a better way to handle the health checks here.
- Silences curl progress, unless there's an error.
  - This quiets down the health check output, which currently looks like this on my system (note the curl output):
![Screenshot 2024-09-18 at 10 30 13 AM](https://github.com/user-attachments/assets/de6a9011-77b4-4356-9f21-309d877e44ac)
