### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you're not new here and looking to upgrade your setup, here's what you need t
  - '7777:7777/udp'
 ```
 
-- Ensue BOTH of the new ports are explicitly allowed through your firewall/port forwarded as needed.
+- Ensure BOTH of the new ports are explicitly allowed through your firewall/port forwarded as needed.
 
 If you're experiencing API connectivity issues, your issue is that you haven't completed one of these two steps. If
 you're seeing a `EADDRINUSE` log message, Coffee Stain confirmed that it does **not** matter. Same applies to the


### PR DESCRIPTION
Fixed "Ensue" to be "Ensure"

I'm not an english expert, but I stumbled upon this word and guessed, that you might just have missed the "r". Hope I'm not overlooking something :D