### PR TITLE
add SSL with certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ following directories:
 - `/backups` - the server will automatically backup your saves when the container first starts
 - `/gamefiles` - this is for the game's files. They're stored outside the container to avoid needing to redownload
   8GB+ every time you want to rebuild the container
-- `/logs` - this holds Steam's logs, and contains a pointer to Satisfactory's logs (empties on startup unless `LOG=true`)
+- `/logs` - this holds Steam's logs, and contains a pointer to Satisfactory's logs (empties on startup unless
+  `LOG=true`)
 - `/saved` - this contains the game's blueprints, saves, and server configuration
 
 Before running the server image, you should find your user ID that will be running the container. This isn't necessary
@@ -142,6 +143,12 @@ services:
           memory: 4G
 ```
 
+### SSL Certificate with Certbot (Optional)
+
+You can use Certbot with Let's Encrypt to issue a signed SSL certificate for your server. Without this,
+Satisfactory will use a self-signed SSL certificate, requiring players to manually confirm them when they initially
+connect. [Learn more](https://github.com/wolveix/satisfactory-server/tree/main/ssl).
+
 ### Kubernetes
 
 If you are running a [Kubernetes](https://kubernetes.io) cluster, we do have
@@ -160,13 +167,6 @@ helm repo add k8s-at-home https://k8s-at-home.com/charts/
 helm repo update
 helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 ```
-
-### SSL Certificate with Certbot
-
-Uses Certbot and Let's Encrypt to generate SSL certificates for the server.
-Without Certbot, the Satisfactory server uses self-signed SSL certificates, requiring players to manually confirm them.
-
-You can read more in the [ssl](https://github.com/wolveix/satisfactory-server/tree/main/ssl) directory.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 Uses Certbot and Let's Encrypt to generate SSL certificates for the server.
 Without Certbot, the Satisfactory server uses self-signed SSL certificates, requiring players to manually confirm them.
 
-You can read more in the [ssl](ssl) directory.
+You can read more in the [ssl](https://github.com/wolveix/satisfactory-server/tree/main/ssl) directory.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ helm repo update
 helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 ```
 
+### SSL Certificate with Certbot
+
+Uses Certbot and Let's Encrypt to generate SSL certificates for the server.
+Without Certbot, the Satisfactory server uses self-signed SSL certificates, requiring players to manually confirm them.
+
+You can read more in the [ssl](ssl) directory.
+
 ## Environment Variables
 
 | Parameter               |  Default  | Function                                                  |

--- a/ssl/.env.example
+++ b/ssl/.env.example
@@ -1,0 +1,2 @@
+DOMAIN=satisfactory.example.com
+CERTBOT_MAIL=certbot@example.com

--- a/ssl/.env.example
+++ b/ssl/.env.example
@@ -1,2 +1,0 @@
-DOMAIN=satisfactory.example.com
-CERTBOT_MAIL=certbot@example.com

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -1,49 +1,100 @@
 # SSL Certificate with Certbot
 
-This setup is based on the already existing [docker-compose.yml](../docker-compose.yml).
+The instructions below will help you to deploy a signed SSL certificate for your Satisfactory server.
 
+## Docker Compose
 
-## Setup
+```yaml
+services:
+  satisfactory-server:
+    container_name: 'satisfactory-server'
+    hostname: 'satisfactory-server'
+    image: 'wolveix/satisfactory-server:latest'
+    ports:
+      - '7777:7777/udp'
+      - '7777:7777/tcp'
+    volumes:
+      - './satisfactory-server:/config'
+      - './certs/live/${DOMAIN}/fullchain.pem:/config/gamefiles/FactoryGame/Certificates/cert_chain.pem'
+      - './certs/live/${DOMAIN}/privkey.pem:/config/gamefiles/FactoryGame/Certificates/private_key.pem'
+    environment:
+      - MAXPLAYERS=4
+      - PGID=1000
+      - PUID=1000
+      - ROOTLESS=false
+      - STEAMBETA=false
+    restart: unless-stopped
+    depends_on:
+      certbot:
+        condition: service_completed_successfully
+    healthcheck:
+      test: bash /healthcheck.sh
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          memory: 6G
+        reservations:
+          memory: 4G
 
-- Copy `docker-compose.yml`
-- Copy `.env.example` and rename it to `.env`
-- Fill in your information in the new `.env` file
-- If you want to change the default config for the server itself, see [Environment Variables](../README.md#environment-variables)
-- Make sure you open the port `80/tcp` additionally
+  certbot:
+    image: certbot/certbot
+    command: certonly --standalone --non-interactive --agree-tos -m ${CERTBOT_MAIL} -d ${DOMAIN}
+    ports:
+      - '80:80/tcp'
+    volumes:
+      - ./certs:/etc/letsencrypt
+    environment:
+      - CERTBOT_MAIL=certbot@domain.tld
+      - DOMAIN=satisfactory.domain.tld
+```
 
-It should now be ready for deployment. Start the process with `docker-compose up -d`.
+The `docker-compose.yml` file above should replace the `docker-compose.yml` file you already have configured. Adjust the
+`CERTBOT_MAIL` and `DOMAIN` environment variables under the `certbot` service to be a real email address, and the domain
+you'd like to issue the SSL certificate for. Ensure prior to running this that you've already created the necessary DNS
+record for your domain. If you don't certbot will fail, and you'll likely hit your rate limit and need to wait a while
+to try again (check the `certbot` container's logs for further information).
 
-Certbot will run before the server starts. If it fails, the server itself will **NOT** start.
+**Ensure that you open/port forward for port `80/tcp`.**
+
+You can now launch the Docker Compose configuration in the same way you normally would. Do note that if Certbot fails,
+the game server will not start.
 
 ## Troubleshooting
 
-### I have a reverse proxy, port 80 is already blocked
+### What if port 80 is already in-use with a reverse-proxy?
 
-This shouldn't be a problem. Just change the port for the certbot service (like `7780:80`) and forward HTTP traffic to certbot.
+Change the port for the certbot service (e.g. `7800:80/tcp`), and forward HTTP traffic from your reverse proxy through
+to your `certbot` container.
 
-Here are some examples for some proxies:
+Here are examples on how you can do this with Caddy and NGINX
+
+#### Caddy
+
+Modify your Caddyfile to include your given domain above. Ensure that you put `http://` **before** the domain, otherwise
+Caddy will _also_ request an SSL certificate for it.
+
+```
+http://satisfactory.domain.tld {
+    reverse_proxy :7780
+}
+```
+
 
 #### NGINX
 
-Should be straightforward, as the simplest setup already uses HTTP instead of HTTPS.
+Modify your NGINX configuration file to include the following virtual host:
 
 ```
 server {
     listen       80;
-    server_name  satisfactory.example.com;
+    server_name  satisfactory.domain.tld;
 
     location / {
         proxy_pass  http://localhost:7780;
     }
 }
 ```
-
-#### Caddy
-
-Put `http://` in front of your domain like this:
-
-`/etc/caddy/Caddyfile`
-```caddyfile
-http://example.com {
-    reverse_proxy :7780
-}

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -1,0 +1,49 @@
+# SSL Certificate with Certbot
+
+This setup is based on the already existing [docker-compose.yml](../docker-compose.yml).
+
+
+## Setup
+
+- Copy `docker-compose.yml`
+- Copy `.env.example` and rename it to `.env`
+- Fill in your information in the new `.env` file
+- If you want to change the default config for the server itself, see [Environment Variables](../README.md#environment-variables)
+- Make sure you open the port `80/tcp` additionally
+
+It should now be ready for deployment. Start the process with `docker-compose up -d`.
+
+Certbot will run before the server starts. If it fails, the server itself will **NOT** start.
+
+## Troubleshooting
+
+### I have a reverse proxy, port 80 is already blocked
+
+This shouldn't be a problem. Just change the port for the certbot service (like `7780:80`) and forward HTTP traffic to certbot.
+
+Here are some examples for some proxies:
+
+#### NGINX
+
+Should be straightforward, as the simplest setup already uses HTTP instead of HTTPS.
+
+```
+server {
+    listen       80;
+    server_name  satisfactory.example.com;
+
+    location / {
+        proxy_pass  http://localhost:7780;
+    }
+}
+```
+
+#### Caddy
+
+Put `http://` in front of your domain like this:
+
+`/etc/caddy/Caddyfile`
+```caddyfile
+http://example.com {
+    reverse_proxy :7780
+}

--- a/ssl/docker-compose.yml
+++ b/ssl/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - '7777:7777/tcp'
     volumes:
       - './satisfactory-server:/config'
-      - './certs/live/${DOMAIN}/privkey.pem:/config/gamefiles/FactoryGame/Certificates/private_key.pem'
       - './certs/live/${DOMAIN}/fullchain.pem:/config/gamefiles/FactoryGame/Certificates/cert_chain.pem'
+      - './certs/live/${DOMAIN}/privkey.pem:/config/gamefiles/FactoryGame/Certificates/private_key.pem'
     environment:
       - MAXPLAYERS=4
       - PGID=1000

--- a/ssl/docker-compose.yml
+++ b/ssl/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  satisfactory-server:
+    container_name: 'satisfactory-server'
+    hostname: 'satisfactory-server'
+    image: 'wolveix/satisfactory-server:latest'
+    ports:
+      - '7777:7777/udp'
+      - '7777:7777/tcp'
+    volumes:
+      - './satisfactory-server:/config'
+      - './certs/live/${DOMAIN}/privkey.pem:/config/gamefiles/FactoryGame/Certificates/private_key.pem'
+      - './certs/live/${DOMAIN}/fullchain.pem:/config/gamefiles/FactoryGame/Certificates/cert_chain.pem'
+    environment:
+      - MAXPLAYERS=4
+      - PGID=1000
+      - PUID=1000
+      - ROOTLESS=false
+      - STEAMBETA=false
+    restart: unless-stopped
+    depends_on:
+      certbot:
+        condition: service_completed_successfully
+    healthcheck:
+      test: bash /healthcheck.sh
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          memory: 6G
+        reservations:
+          memory: 4G
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./certs:/etc/letsencrypt
+    command: certonly --standalone --non-interactive --agree-tos -m ${CERTBOT_MAIL} -d ${DOMAIN}
+    ports:
+      - "80:80"

--- a/ssl/docker-compose.yml
+++ b/ssl/docker-compose.yml
@@ -35,8 +35,11 @@ services:
 
   certbot:
     image: certbot/certbot
-    volumes:
-      - ./certs:/etc/letsencrypt
     command: certonly --standalone --non-interactive --agree-tos -m ${CERTBOT_MAIL} -d ${DOMAIN}
     ports:
-      - "80:80"
+      - '80:80/tcp'
+    volumes:
+      - ./certs:/etc/letsencrypt
+    environment:
+      - CERTBOT_MAIL=certbot@domain.tld
+      - DOMAIN=satisfactory.domain.tld


### PR DESCRIPTION
Basic setup to automatically generate an SSL certificate for a specified domain. Always runs before the satisfactory server and renews the certificate if necessary.