### PR TITLE
Add tzdata package for Docker TZ environment variable usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM steamcmd/steamcmd:ubuntu-22
 # hadolint ignore=DL3008
 RUN set -x \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y gosu xdg-user-dirs curl jq --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y gosu xdg-user-dirs curl jq tzdata --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && useradd -ms /bin/bash steam \
  && gosu nobody true


### PR DESCRIPTION
Add tzdata package for Docker TZ environment variable usage. Without that package installed the container doesn't know how to apply any timezone changes/offsets.