### PR TITLE
Fix for Kubernetes manifests

### DIFF
--- a/cluster/service.yaml
+++ b/cluster/service.yaml
@@ -17,7 +17,7 @@ spec:
       port: 7777
       protocol: UDP
       targetPort: 7777
-    - name: "gametcp"
+    - name: "api"
       port: 7777
       protocol: TCP
       targetPort: 7777

--- a/cluster/service.yaml
+++ b/cluster/service.yaml
@@ -10,6 +10,8 @@ spec:
   allocateLoadBalancerNodePorts: true
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
+# might be necessary for your cluster:
+#  loadBalancerIP: <external-IP>
   ports:
     - name: "game"
       port: 7777

--- a/cluster/service.yaml
+++ b/cluster/service.yaml
@@ -6,17 +6,18 @@ metadata:
   labels:
     app: satisfactory
 spec:
-  type: NodePort
+  type: LoadBalancer
+  allocateLoadBalancerNodePorts: true
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
   ports:
-    - port: 7777
-      nodePort: 7777
+    - name: "game"
+      port: 7777
       protocol: UDP
-      name: "game"
       targetPort: 7777
-    - port: 7777
-      nodePort: 7777
+    - name: "gametcp"
+      port: 7777
       protocol: TCP
-      name: "gametcp"
       targetPort: 7777
   selector:
     app: satisfactory

--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -31,18 +31,27 @@ spec:
             - name: STEAMBETA
               value: "false"
           ports:
-            - containerPort: 7777
-              name: "gameTCP"
+            - name: "gametcp"
+              containerPort: 7777
               protocol: TCP
-            - containerPort: 7777
-              name: "game"
+            - name: "game"
+              containerPort: 7777
               protocol: UDP
           volumeMounts:
-            - name: satisfactory-data
+            - name: satisfactory-config
               mountPath: /config
+            - name: satisfactory-server-cache
+              mountPath: /config/gamefiles
   volumeClaimTemplates:
     - metadata:
-        name: satisfactory-data
+        name: satisfactory-config
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: satisfactory-server-cache
       spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:

--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
           volumeMounts:
             - name: satisfactory-config
               mountPath: /config
-            - name: satisfactory-server-cache
+            - name: satisfactory-data
               mountPath: /config/gamefiles
   volumeClaimTemplates:
     - metadata:

--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
             - name: STEAMBETA
               value: "false"
           ports:
-            - name: "gametcp"
+            - name: "api"
               containerPort: 7777
               protocol: TCP
             - name: "game"

--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
           requests:
             storage: 1Gi
     - metadata:
-        name: satisfactory-server-cache
+        name: satisfactory-data
       spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:


### PR DESCRIPTION
At least on my K8s version 1.28.6 the manifests generated some errors:
* "gameTCP" is a non-compliant port name in statefulset and also does not match service manifest
* I believe the YAML port lists need different keys, for me always only one port was created instead of TCP + UDP
* a service of type "nodePort" cannot expose port numbers below 30000, LoadBalancer is the right one imho

So I changed those things and in addition
* separate /config and /config/gamefiles into 1Gi and 20Gi different persistent volumes (like the k8s-at-home chart does)

I am not sure if the service also needs a
loadBalancerIP: <external IP>

Unfortunately the k8s-at-home helm chart has not been updated yet, so I also hacked my own custom helm chart together with these manifests, I could also add this to your repo.