### PR TITLE
Move healthcheck into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN mkdir -p /config \
 COPY init.sh healthcheck.sh /
 COPY --chown=steam:steam run.sh /home/steam/
 
+HEALTHCHECK --timeout=10s --start-period=120s \
+  CMD bash /healthcheck.sh
+
 WORKDIR /config
 
 ARG VERSION="DEV"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /config \
 COPY init.sh healthcheck.sh /
 COPY --chown=steam:steam run.sh /home/steam/
 
-HEALTHCHECK --timeout=10s --start-period=120s \
+HEALTHCHECK --timeout=10s --start-period=180s \
   CMD bash /healthcheck.sh
 
 WORKDIR /config

--- a/README.md
+++ b/README.md
@@ -129,12 +129,6 @@ services:
       - ROOTLESS=false
       - STEAMBETA=false
     restart: unless-stopped
-    healthcheck:
-      test: bash /healthcheck.sh
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,6 @@ services:
       - ROOTLESS=false
       - STEAMBETA=false
     restart: unless-stopped
-    healthcheck:
-      test: bash /healthcheck.sh
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
     deploy:
       resources:
         limits:

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -27,12 +27,6 @@ services:
     depends_on:
       certbot:
         condition: service_completed_successfully
-    healthcheck:
-      test: bash /healthcheck.sh
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
     deploy:
       resources:
         limits:

--- a/ssl/docker-compose.yml
+++ b/ssl/docker-compose.yml
@@ -20,12 +20,6 @@ services:
     depends_on:
       certbot:
         condition: service_completed_successfully
-    healthcheck:
-      test: bash /healthcheck.sh
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
     deploy:
       resources:
         limits:


### PR DESCRIPTION
... thus the health check is also available when using a simple `docker run ...`.

Or does something speak against it @wolveix @dieser-niko @ashfire908 ?