### PR TITLE
Updat memory reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run \
 --env PUID=1000 \
 --env ROOTLESS=false \
 --env STEAMBETA=false \
---memory-reservation=4G \
+--memory-reservation=2G \
 --memory 6G \
 --publish 7777:7777/udp \
 --publish 7777:7777/tcp \
@@ -140,7 +140,7 @@ services:
         limits:
           memory: 6G
         reservations:
-          memory: 4G
+          memory: 2G
 ```
 
 ### SSL Certificate with Certbot (Optional)


### PR DESCRIPTION
I recently noticed that my satisactory server only uses 2GB so reserving 4GB is too much imo.
The RAM usage does shoot up when a few players join (in my case up to 5.4GB with 3 players and a late game world).
But I do think that this is some kind of bug as after a restart the server only uses 2 GB even with a players.

TLDR:
- Server uses only 2GB so 4GB is too much
- Server still can shot up to 6GB so that is not getting touched (for now as this may be a memory issue)