### PR TITLE
fix README.md explanation of "--memory 8G"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ wolveix/satisfactory-server:latest
 * For the environment (`--env`) variables please
   see [here](https://github.com/wolveix/satisfactory-server#environment-variables)
 * `--memory-reservation=4G` -> Reserves 4GB RAM from the host for the container's use
-* `--memory 8G` -> Restricts the container to 6GB RAM
+* `--memory 8G` -> Restricts the container to 8GB RAM
 * `--publish` -> Specifies the ports that the container exposes<br>
 
 </details>


### PR DESCRIPTION
with the latest release, the memory-limit got changed to 8GB - in the Explanation of the command it still said this limits the container to 6GB :D  