### PR TITLE
Update the SSL readme to make it clearer that you can't connect with your local IP

### DIFF
--- a/ssl/README.md
+++ b/ssl/README.md
@@ -65,6 +65,7 @@ If you could reach the server before configuring a signed SSL cert, ensure that 
 following:
 - Using a wildcard cert: Satisfactory does not support them ([#354](https://github.com/wolveix/satisfactory-server/issues/354))
 - Connecting to a hostname not specified in your cert: Satisfactory does not support this ([#354](https://github.com/wolveix/satisfactory-server/issues/354))
+  - This means that **you can't connect using your local IP**. Doing so will give a "Failed to connect to Server API" error.
 
 ### What if port 80 is already in-use with a reverse-proxy?
 

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -65,7 +65,7 @@ If you could reach the server before configuring a signed SSL cert, ensure that 
 following:
 - Using a wildcard cert: Satisfactory does not support them ([#354](https://github.com/wolveix/satisfactory-server/issues/354))
 - Connecting to a hostname not specified in your cert: Satisfactory does not support this ([#354](https://github.com/wolveix/satisfactory-server/issues/354))
-  - This means that **you can't connect using your local IP**. Doing so will give a "Failed to connect to Server API" error.
+- Using your local IP. You cannot use your local IP, as it will not be included in your certificate.
 
 ### What if port 80 is already in-use with a reverse-proxy?
 


### PR DESCRIPTION
Although this should be a straight-forward deduction from the existing notes, this would have saved me an hour of trying to figure out why the server "wasn't working".