### PR TITLE
Reintroduction of the MULTIHOME parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV AUTOSAVENUM="5" \
     MAXOBJECTS="2162688" \
     MAXPLAYERS="4" \
     MAXTICKRATE="30" \
+    MULTIHOME="::" \
     PGID="1000" \
     PUID="1000" \
     ROOTLESS="false" \
@@ -19,8 +20,7 @@ ENV AUTOSAVENUM="5" \
     STEAMAPPID="1690800" \
     STEAMBETA="false" \
     TIMEOUT="30" \
-    VMOVERRIDE="false" \
-    MULTIHOME="::"
+    VMOVERRIDE="false"
 
 # hadolint ignore=DL3008
 RUN set -x \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV AUTOSAVENUM="5" \
     STEAMAPPID="1690800" \
     STEAMBETA="false" \
     TIMEOUT="30" \
-    VMOVERRIDE="false"
+    VMOVERRIDE="false" \
+    MULTIHOME="::"
 
 # hadolint ignore=DL3008
 RUN set -x \

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 | `MAXOBJECTS`            | `2162688` | set the object limit for your server                      |
 | `MAXPLAYERS`            |    `4`    | set the player limit for your server                      |
 | `MAXTICKRATE`           |   `30`    | set the maximum sim tick rate for your server             |
+| `MULTIHOME`             |   `::`    | set the server's listening interface (usually not needed) |
 | `PGID`                  |  `1000`   | set the group ID of the user the server will run as       |
 | `PUID`                  |  `1000`   | set the user ID of the user the server will run as        |
 | `ROOTLESS`              |  `false`  | run the container as a non-root user                      |
 | `SERVERGAMEPORT`        |  `7777`   | set the game's port                                       |
-| `MULTIHOME`             |   `::`    | set the servers listening interfaces (usually not needed) |
 | `SERVERSTREAMING`       |  `true`   | toggle whether the game utilizes asset streaming          |
 | `SKIPUPDATE`            |  `false`  | avoid updating the game on container start/restart        |
 | `STEAMBETA`             |  `false`  | set experimental game version                             |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 | `PUID`                  |  `1000`   | set the user ID of the user the server will run as        |
 | `ROOTLESS`              |  `false`  | run the container as a non-root user                      |
 | `SERVERGAMEPORT`        |  `7777`   | set the game's port                                       |
-| `SERVERIP`              | `0.0.0.0` | set the game's ip (usually not needed)                    |
+| `MULTIHOME`             |   `::`    | set the servers listening interfaces (usually not needed) |
 | `SERVERSTREAMING`       |  `true`   | toggle whether the game utilizes asset streaming          |
 | `SKIPUPDATE`            |  `false`  | avoid updating the game on container start/restart        |
 | `STEAMBETA`             |  `false`  | set experimental game version                             |

--- a/run.sh
+++ b/run.sh
@@ -48,14 +48,20 @@ fi
 if [[ "$MULTIHOME" != "::" ]]; then
     # Check if it's a valid IPv4 address (0-255 segments).
     if [[ "$MULTIHOME" =~ ^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]]; then
-        printf "Multihome will accept IPv4 connections only\\n"
-    # Check if it's a valid IPv6 address.
-    elif [[ "$MULTIHOME" =~ ^([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}$ ]]; then
-        # FIXME: doesn't support IPv6 shorthand, e.g. 2041:0000:140F::875B:131B.
-        printf "Multihome will accept IPv6 connections only\\n"
+        printf "Accepting IPv4 connections only on %s\n" "$MULTIHOME"
+    # Basic IPv6 validation, allowing shorthand (some invalid ones may still pass here).
+    elif [[ "$MULTIHOME" =~ ^(([0-9a-fA-F]{0,4}::?){0,7})([0-9a-fA-F]{1,4})(::)?$ ]]; then
+        printf "Trying to accept IPv6 connections only on %s\n" "$MULTIHOME"
     else
-        printf "Invalid multihome address given: %s\n" "$MULTIHOME"
-        MULTIHOME="::"
+        printf "\e[31mInvalid IP address given: %s\e[0m\n" "$MULTIHOME"
+    fi
+
+    printf "Testing given Interface: " # Should always be reachable since localhost, practically checks if interface exists
+    if ping -c 1 "$MULTIHOME"; then
+        printf "\e[32mValid and reachable: %s\e[0m\n" "$MULTIHOME" 
+    else
+        printf "\e[31mInvalid or unreachable: %s\e[0m\n" "$MULTIHOME"
+        exit 1 # Fail LOUDLY as to prevent the need to dig through the log
     fi
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,27 @@ if ! [[ "$MAXTICKRATE" =~ $NUMCHECK ]] ; then
 fi
 printf "Setting max tick rate to %s\\n" "$MAXTICKRATE"
 
+if [[ "$MULTIHOME" != "::" ]]; then
+    if [[ "$MULTIHOME" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+        # Check if it's a valid IPv4 address (0-255 segments)
+        if echo "$MULTIHOME" | awk -F. '$1<=255 && $2<=255 && $3<=255 && $4<=255'; then
+            if [[ "$MULTIHOME" == "0.0.0.0" ]]; then
+                printf "Restricting Server to IPv4 on all interfaces\n"
+            else
+                printf "Setting custom IPv4 as Interface: %s\n" "$MULTIHOME"
+            fi
+        else
+            printf "Invalid IPv4 address: %s\n" "$MULTIHOME"
+        fi
+    elif [[ "$MULTIHOME" =~ ^([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}$ ]]; then
+        printf "Setting custom IPv6 as Interface: %s\n" "$MULTIHOME"
+    else
+        # server handles this non-graciously
+        printf "Invalid IP address: %s\n" "$MULTIHOME"
+        exit 1
+    fi
+fi
+
 [[ "${SERVERSTREAMING,,}" == "true" ]] && SERVERSTREAMING="1" || SERVERSTREAMING="0"
 printf "Setting server streaming to %s\\n" "$SERVERSTREAMING"
 
@@ -58,6 +79,7 @@ ini_args=(
   "-ini:Game:[/Script/Engine.GameSession]:MaxPlayers=$MAXPLAYERS"
   "-ini:GameUserSettings:[/Script/Engine.GameSession]:MaxPlayers=$MAXPLAYERS"
   "$DISABLESEASONALEVENTS"
+  "-multihome=$MULTIHOME"
 )
 
 if [[ "${SKIPUPDATE,,}" != "false" ]] && [ ! -f "/config/gamefiles/FactoryServer.sh" ]; then


### PR DESCRIPTION
Reintroduction of the Multihome parameter for better compatibility with complex networks.

Seemingly allows better operation on IPv6 only networks

Caused by:
https://github.com/wolveix/satisfactory-server/issues/301
