### PR TITLE
Fix Steamcmd download error (#389)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN set -x \
  && rm -rf /var/lib/apt/lists/* \
  && groupadd -g ${GID} steam \
  && useradd -u ${UID} -g ${GID} -ms /bin/bash steam \
+ && mkdir -p /home/steam/.local/share/Steam/ \
+ && cp -R /root/.local/share/Steam/steamcmd/ /home/steam/.local/share/Steam/steamcmd/ \
+ && chown -R ${UID}:${GID} /home/steam/.local/ \
  && gosu nobody true
 
 RUN mkdir -p /config \


### PR DESCRIPTION
Copy some Steam files to the newly created user's home directory. Apparently this fixes my error. Both for running as root and as non-root (user 1000).

Closes #389.