### PR TITLE
Fix mount volume path for sftp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,14 @@ services:
     container_name: 'sftp-server'
     image: 'atmoz/sftp:latest'
     volumes:
-      - './satisfactory-server:/home/your-ftp-user'
+      - './satisfactory-server:/home/your-ftp-user/satisfactory-server'
     ports:
       - '2222:22'
     # set the user and password, and the user's UID (this should match the PUID and PGID of the satisfactory-server container)
     command: 'your-ftp-user:your-ftp-password:1000'
 ```
 
-With this, you'll be able to SFTP into your server and access your game files via `/home/your-ftp-user/gamefiles`.
+With this, you'll be able to SFTP into your server and access your game files via `/home/your-ftp-user/satisfactory-server/gamefiles`.
 
 ## How to Improve the Multiplayer Experience
 


### PR DESCRIPTION
This PR fixes README instructions for adding an sftp server for modding (check [atmoz/sftp#examples](https://github.com/atmoz/sftp?tab=readme-ov-file#examples)). 


Current instructions mount `./satisfactory-server`  path directly under the sftp user home directory `/home/your-ftp-user` which causes chroot failure. 
```
root@myserver:~/modded-satisfactory# docker compose logs -f sftp-server
sftp-server  | [/usr/local/bin/create-sftp-user] Parsing user data: "myuser:mypassword:1000"
sftp-server  | Generating public/private ed25519 key pair.
sftp-server  | Your identification has been saved in /etc/ssh/ssh_host_ed25519_key
sftp-server  | Your public key has been saved in /etc/ssh/ssh_host_ed25519_key.pub
sftp-server  | The key fingerprint is:
sftp-server  | SHA256:vMpssNSPT4YQJrU5WnQ6tzd8/h+UXZFadwGoJpMN0fQ root@modded-satisfactory-server
sftp-server  | The key's randomart image is:
sftp-server  | +--[ED25519 256]--+
sftp-server  | |    o ..+.  ...oo|
sftp-server  | |   o = . ...   o+|
sftp-server  | |  . X . + .E  o +|
sftp-server  | |   = = B +   . o.|
sftp-server  | |  . ... S .   o .|
sftp-server  | |    o..o =   .   |
sftp-server  | |   . o.o+ .   .  |
sftp-server  | |    .oo+.  .   . |
sftp-server  | |     .+..   ...  |
sftp-server  | +----[SHA256]-----+
sftp-server  | Generating public/private rsa key pair.
sftp-server  | Your identification has been saved in /etc/ssh/ssh_host_rsa_key
sftp-server  | Your public key has been saved in /etc/ssh/ssh_host_rsa_key.pub
sftp-server  | The key fingerprint is:
sftp-server  | SHA256:6rFtVHYA3Kty8o3gMrg6x1UmKlXY+tcFdiLv9xZ2Uh0 root@modded-satisfactory-server
sftp-server  | The key's randomart image is:
sftp-server  | +---[RSA 4096]----+
sftp-server  | |   o   ..o       |
sftp-server  | |  . o . = +    E |
sftp-server  | |   o   + + o   ..|
sftp-server  | |  o . o . = . . .|
sftp-server  | | . o + oS= . .   |
sftp-server  | |. . o =.* . + .  |
sftp-server  | | o o ooB + o +   |
sftp-server  | |. + o..++ . o    |
sftp-server  | |.+.. oo..  .     |
sftp-server  | +----[SHA256]-----+
sftp-server  | [/entrypoint] Executing sshd
sftp-server  | Server listening on 0.0.0.0 port 22.
sftp-server  | Server listening on :: port 22.
sftp-server  | Connection closed by REDACTED port 65242 [preauth]
sftp-server  | Connection closed by REDACTED port 65276 [preauth]
sftp-server  | Accepted password for myuser from REDACTED port 65220 ssh2
sftp-server  | bad ownership or modes for chroot directory "/home/myuser"
```

We just need to mount it under `/home/your-ftp-user/satisfactory-server` instead. Then we can access the gamefiles under `/home/your-ftp-user/satisfactory-server/gamefiles` instead of `/home/your-ftp-user/gamefiles`