### PR TITLE
Add and document new environmental variables for using custom beta versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ENV AUTOSAVENUM="5" \
     SKIPUPDATE="false" \
     STEAMAPPID="1690800" \
     STEAMBETA="false" \
+    STEAMBETAID="" \
+    STEAMBETAKEY="" \
     TIMEOUT="30" \
     VMOVERRIDE="false"
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 | `SERVERSTREAMING`       |  `true`   | toggle whether the game utilizes asset streaming          |
 | `SKIPUPDATE`            |  `false`  | avoid updating the game on container start/restart        |
 | `STEAMBETA`             |  `false`  | set experimental game version                             |
-| `STEAMBETAID`           | `tech-su` | set a custom beta game version                            |
-| `STEAMBETAKEY`          | `passwd`  | set password for the beta game version                    |
+| `STEAMBETAID`           |           | set a custom beta game version (for testing)              |
+| `STEAMBETAKEY`          |           | set password for the beta game version (for testing)      |
 | `TIMEOUT`               |   `30`    | set client timeout (in seconds)                           |
 | `VMOVERRIDE`            |  `false`  | skips the CPU model check (should not ordinarily be used) |
 
@@ -190,8 +190,8 @@ community [here](https://docs.ficsit.app/satisfactory-modding/latest/ForUsers/De
 
 The container does **NOT** have an S/FTP server installed directly, as Docker images are intended to carry a single
 function/process. You can either SFTP into your host that houses the Satisfactory server (trivial to do if you're
-running Linux), or alternatively you can spin up an S/FTP server through the use of another Docker container using the
-Docker Compose example listed below:
+running Linux), or you can spin up an S/FTP server through the use of another Docker container using the Docker Compose
+example listed below:
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 | `SERVERSTREAMING`       |  `true`   | toggle whether the game utilizes asset streaming          |
 | `SKIPUPDATE`            |  `false`  | avoid updating the game on container start/restart        |
 | `STEAMBETA`             |  `false`  | set experimental game version                             |
+| `STEAMBETAID`           | `tech-su` | set a custom beta game version                            |
+| `STEAMBETAPASSWORD`     |  `false`  | set password for beta game version                        |
 | `TIMEOUT`               |   `30`    | set client timeout (in seconds)                           |
 | `VMOVERRIDE`            |  `false`  | skips the CPU model check (should not ordinarily be used) |
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ helm install satisfactory k8s-at-home/satisfactory -f values.yaml
 | `SKIPUPDATE`            |  `false`  | avoid updating the game on container start/restart        |
 | `STEAMBETA`             |  `false`  | set experimental game version                             |
 | `STEAMBETAID`           | `tech-su` | set a custom beta game version                            |
-| `STEAMBETAPASSWORD`     |  `false`  | set password for beta game version                        |
+| `STEAMBETAKEY`          | `passwd`  | set password for the beta game version                    |
 | `TIMEOUT`               |   `30`    | set client timeout (in seconds)                           |
 | `VMOVERRIDE`            |  `false`  | skips the CPU model check (should not ordinarily be used) |
 

--- a/run.sh
+++ b/run.sh
@@ -107,22 +107,19 @@ if [[ "${SKIPUPDATE,,}" != "false" ]] && [ ! -f "/config/gamefiles/FactoryServer
 fi
 
 if [[ "${SKIPUPDATE,,}" != "true" ]]; then
+    BETAPASSWORD=""
     if [[ -n "${STEAMBETAID}" ]]; then
         printf "STEAMBETAID is set. Using beta ID: %s\\n" "$STEAMBETAID"
         STEAMBETAFLAG="$STEAMBETAID"
         if [[ -n "${STEAMBETAKEY}" ]]; then
             BETAPASSWORD="-betapassword $STEAMBETAKEY"
             printf "Beta password provided\\n"
-        else
-            BETAPASSWORD=""
         fi
     elif [[ "${STEAMBETA,,}" == "true" ]]; then
         printf "Experimental flag is set. Experimental will be downloaded instead of Early Access.\\n"
         STEAMBETAFLAG="experimental"
-        BETAPASSWORD=""
     else
         STEAMBETAFLAG="public"
-        BETAPASSWORD=""
     fi
 
     STORAGEAVAILABLE=$(stat -f -c "%a*%S" .)

--- a/run.sh
+++ b/run.sh
@@ -107,12 +107,13 @@ if [[ "${SKIPUPDATE,,}" != "false" ]] && [ ! -f "/config/gamefiles/FactoryServer
 fi
 
 if [[ "${SKIPUPDATE,,}" != "true" ]]; then
-    BETAPASSWORD=""
+    STEAMBETAPASSWORD=""
+
     if [[ -n "${STEAMBETAID}" ]]; then
         printf "STEAMBETAID is set. Using beta ID: %s\\n" "$STEAMBETAID"
         STEAMBETAFLAG="$STEAMBETAID"
         if [[ -n "${STEAMBETAKEY}" ]]; then
-            BETAPASSWORD="-betapassword $STEAMBETAKEY"
+            STEAMBETAPASSWORD="-betapassword $STEAMBETAKEY"
             printf "Beta password provided\\n"
         fi
     elif [[ "${STEAMBETA,,}" == "true" ]]; then
@@ -135,7 +136,7 @@ if [[ "${SKIPUPDATE,,}" != "true" ]]; then
         printf "\\nRemoving the app manifest to force Steam to check for an update...\\n"
         rm "/config/gamefiles/steamapps/appmanifest_1690800.acf" || true
     fi
-    steamcmd +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID" -beta "$STEAMBETAFLAG" $BETAPASSWORD validate +quit
+    steamcmd +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID" -beta "$STEAMBETAFLAG" $STEAMBETAPASSWORD validate +quit
     cp -r /home/steam/.steam/steam/logs/* "/config/logs/steam" || printf "Failed to store Steam logs\\n"
 else
     printf "Skipping update as flag is set\\n"

--- a/run.sh
+++ b/run.sh
@@ -107,11 +107,22 @@ if [[ "${SKIPUPDATE,,}" != "false" ]] && [ ! -f "/config/gamefiles/FactoryServer
 fi
 
 if [[ "${SKIPUPDATE,,}" != "true" ]]; then
-    if [[ "${STEAMBETA,,}" == "true" ]]; then
+    if [[ -n "${STEAMBETAID}" ]]; then
+        printf "STEAMBETAID is set. Using beta ID: %s\\n" "$STEAMBETAID"
+        STEAMBETAFLAG="$STEAMBETAID"
+        if [[ -n "${STEAMBETAKEY}" ]]; then
+            BETAPASSWORD="-betapassword $STEAMBETAKEY"
+            printf "Beta password provided\\n"
+        else
+            BETAPASSWORD=""
+        fi
+    elif [[ "${STEAMBETA,,}" == "true" ]]; then
         printf "Experimental flag is set. Experimental will be downloaded instead of Early Access.\\n"
         STEAMBETAFLAG="experimental"
+        BETAPASSWORD=""
     else
         STEAMBETAFLAG="public"
+        BETAPASSWORD=""
     fi
 
     STORAGEAVAILABLE=$(stat -f -c "%a*%S" .)
@@ -127,7 +138,7 @@ if [[ "${SKIPUPDATE,,}" != "true" ]]; then
         printf "\\nRemoving the app manifest to force Steam to check for an update...\\n"
         rm "/config/gamefiles/steamapps/appmanifest_1690800.acf" || true
     fi
-    steamcmd +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID" -beta "$STEAMBETAFLAG" validate +quit
+    steamcmd +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID" -beta "$STEAMBETAFLAG" $BETAPASSWORD validate +quit
     cp -r /home/steam/.steam/steam/logs/* "/config/logs/steam" || printf "Failed to store Steam logs\\n"
 else
     printf "Skipping update as flag is set\\n"


### PR DESCRIPTION
Add support for specifying any beta when testing in-development changes from the studio.

New environmental variables which override STEAMBETA:
STEAMBETAID: public, experimental, tech-support, etc..
STEAMBETAKEY: password for the beta