### PR TITLE
Add liveness probe

### DIFF
--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -45,6 +45,16 @@ spec:
               mountPath: /config
             - name: satisfactory-data
               mountPath: /config/gamefiles
+          livenessProbe:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "curl -k -f -s -S -X POST https://localhost:${SERVERGAMEPORT}/api/v1 -H \"Content-Type: application/json\" -d '{\"function\":\"HealthCheck\",\"data\":{\"clientCustomData\":\"\"}}' -o /dev/null -s -w \"%{http_code}\""
+            initialDelaySeconds: 300
+            failureThreshold: 4
+            successThreshold: 1
+            periodSeconds: 30
   volumeClaimTemplates:
     - metadata:
         name: satisfactory-config

--- a/cluster/statefulset.yaml
+++ b/cluster/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
               command:
               - "/bin/sh"
               - "-c"
-              - "curl -k -f -s -S -X POST https://localhost:${SERVERGAMEPORT}/api/v1 -H \"Content-Type: application/json\" -d '{\"function\":\"HealthCheck\",\"data\":{\"clientCustomData\":\"\"}}' -o /dev/null -s -w \"%{http_code}\""
+              - "/home/steam/healthcheck.sh"
             initialDelaySeconds: 300
             failureThreshold: 4
             successThreshold: 1


### PR DESCRIPTION
Adds the healthcheck already available for docker-compose deployments but now for the kubernetes statefulset.

This also resolves an issue that I have been encountering where after a arbitrary amount of time of running the server's game port typically 7777 would remain open but not handle any incoming requests making the server appear offline. The reason as to why it no longer suffers from that issue when there is a healthcheck is unknown to me.

Regardless having this healthcheck available for a statefullset in the form of a livenessprobe will ensure that it will atleast try and restart if something happens to the satisfactory server making it not respond.