### PR TITLE
README.md: Update path to .ini config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ your client to
 really get the best out of multiplayer:
 
 - Press `WIN + R`
-- Enter `%localappdata%/FactoryGame/Saved/Config/WindowsNoEditor`
+- Enter `%localappdata%/FactoryGame/Saved/Config/Windows`
 - Copy the config data from the wiki into the respective files
 - Right-click each of the 3 config files (Engine.ini, Game.ini, Scalability.ini)
 - Go to Properties > tick Read-only under the attributes


### PR DESCRIPTION
The `WindowsNoEditor` folder is for Unreal Engine 4. However, Unreal Engine 5 (what the game has been using since Early Access Update 8) uses the `Windows` folder instead.